### PR TITLE
Update intellij plugin setup instructions for IntelliJ 2023.2

### DIFF
--- a/website/templates/setup/intellij.html
+++ b/website/templates/setup/intellij.html
@@ -3,9 +3,9 @@
 <@s.scaffold title="IntelliJ IDEA">
 	<@s.introduction>
 		<p>
-			The <a href="https://www.jetbrains.com/idea/">Jetbrains IntelliJ IDEA</a> editor is compatible with lombok without a plugin as of version 2020.3.
+			The <a href="https://www.jetbrains.com/idea/">Jetbrains IntelliJ IDEA</a> editor is compatible with lombok without a plugin as of version 2020.3 to version 2023.1.
 		</p><p>
-			For versions prior to 2020.3, you can add the <a href="https://plugins.jetbrains.com/plugin/6317">Lombok IntelliJ plugin</a> to add lombok support for IntelliJ:
+			For versions prior to 2020.3 or later than 2023.1, you can add the <a href="https://plugins.jetbrains.com/plugin/6317">Lombok IntelliJ plugin</a> to add lombok support for IntelliJ:
 			<ul><li>
 				Go to <code>File &gt; Settings &gt; Plugins</code>
 			</li><li>


### PR DESCRIPTION
Since 2023.2, the Lombok plugin is no longer bundled with IntelliJ

(see https://github.com/JetBrains/intellij-community/commit/654a84f27f2ffec61164bdace5fb7b0e4c88f285)